### PR TITLE
Remove unused dependencies

### DIFF
--- a/traversal.egg
+++ b/traversal.egg
@@ -6,7 +6,6 @@
  (license "LGPL")
  (synopsis "Various list operations")
  (dependencies srfi-1 vector-lib)
- (test-dependencies test)
  (components (extension traversal
                         (inline-file)
                         (types-file)

--- a/traversal.meta
+++ b/traversal.meta
@@ -5,9 +5,7 @@
  (maintainer "Andrei Barbu")
  (license "LGPL")
  (synopsis "Various list operations")
- (depends setup-helper miscmacros
-          check-errors condition-utils vector-lib)
- (test-depends test)
+ (depends setup-helper vector-lib)
  (files "traversal.meta" 
         "traversal.release-info"
         "traversal.scm" 


### PR DESCRIPTION
* The egg has no test suite, so the test dependency on the `test` egg
  is not necessary.

* The `miscmacros`, `check-errors` and `condition-utils` eggs are not
  used in this repository, so they are not needed as dependencies.